### PR TITLE
cypress-ci-block-pr

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Run Cypress
         uses: cypress-io/github-action@v5
+        with:
+          working-directory: ./E2E_tests
 
       - name: Update PR status
         if: always()

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -12,6 +12,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -24,7 +32,6 @@ jobs:
       - name: Run Cypress
         uses: cypress-io/github-action@v5
         with:
-          auto-cancel-after-failures: 1
           working-directory: ./E2E_tests
 
       - name: Update PR status

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -10,38 +10,46 @@ jobs:
       WORKING_DIR: ./E2E_tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
+      # - name: Cache dependencies
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       node_modules
+      #       ~/.cache/Cypress
+      #     key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.17.1
+          cache: "yarn"
 
       - name: Install dependencies
         working-directory: ${{ env.WORKING_DIR }}
         run: yarn install --frozen-lockfile
 
-      - name: Run Cypress
-        uses: cypress-io/github-action@v5
-        with:
-          working-directory: ./E2E_tests
+      - name: Run Cypress tests with fail-fast
+        working-directory: ./E2E_tests
+        run: yarn cypress run --browser chrome
+        env:
+          CYPRESS_FAIL_FAST_STRATEGY: "run"
+          CYPRESS_FAIL_FAST_PLUGIN: true
 
-      - name: Update PR status
-        if: always()
-        run: |
-          if [ "${{ job.status }}" == "success" ]; then
-            echo "Tests passed!"
-          else
-            echo "Tests failed - PR cannot be merged"
-          fi
+      # - name: Run Cypress
+      #   uses: cypress-io/github-action@v5
+      #   with:
+      #     working-directory: ./E2E_tests
+
+      # - name: Update PR status
+      #   if: always()
+      #   run: |
+      #     if [ "${{ job.status }}" == "success" ]; then
+      #       echo "Tests passed!"
+      #     else
+      #       echo "Tests failed - PR cannot be merged"
+      #     fi
 
       # - name: Run Cypress tests
       #   working-directory: ${{ env.WORKING_DIR }}

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -6,23 +6,33 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
-    env:  
+    env:
       WORKING_DIR: ./E2E_tests
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 22.17.1
-          cache: 'yarn'
-          cache-dependency-path: E2E_tests/yarn.lock
+      - name: Run Cypress
+        uses: cypress-io/github-action@v5
 
-      - name: Install dependencies
-        working-directory: ${{ env.WORKING_DIR }}
-        run: yarn install --frozen-lockfile --prefer-offline
+      - name: Update PR status
+        if: always()
+        run: |
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "Tests passed!"
+          else
+            echo "Tests failed - PR cannot be merged"
+          fi
 
-      - name: Run Cypress tests
-        working-directory: ${{ env.WORKING_DIR }}
-        run: yarn test
+      # - name: Setup Node.js
+      #   uses: actions/setup-node@v3
+      #   with:
+      #     node-version: 22.17.1
+
+      # - name: Install dependencies
+      #   working-directory: ${{ env.WORKING_DIR }}
+      #   run: yarn install --frozen-lockfile
+
+      # - name: Run Cypress tests
+      #   working-directory: ${{ env.WORKING_DIR }}
+      #   run: yarn test --quiet --reporter minimal

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
       # Кеширование node_modules и Cypress
       - name: Cache dependencies and Cypress
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.WORKING_DIR }}/node_modules

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -12,6 +12,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22.17.1
+
+      - name: Install dependencies
+        working-directory: ${{ env.WORKING_DIR }}
+        run: yarn install --frozen-lockfile
+
       - name: Run Cypress
         uses: cypress-io/github-action@v5
 
@@ -23,15 +32,6 @@ jobs:
           else
             echo "Tests failed - PR cannot be merged"
           fi
-
-      # - name: Setup Node.js
-      #   uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 22.17.1
-
-      # - name: Install dependencies
-      #   working-directory: ${{ env.WORKING_DIR }}
-      #   run: yarn install --frozen-lockfile
 
       # - name: Run Cypress tests
       #   working-directory: ${{ env.WORKING_DIR }}

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -12,20 +12,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # - name: Cache dependencies
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       node_modules
-      #       ~/.cache/Cypress
-      #     key: ${{ runner.os }}-cypress-${{ hashFiles('yarn.lock') }}
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22.17.1
-          cache: "yarn"
-          cache-dependency-path: ${{ env.WORKING_DIR }}/yarn.lock
 
       # Кеширование node_modules и Cypress
       - name: Cache dependencies and Cypress
@@ -35,6 +25,8 @@ jobs:
             ${{ env.WORKING_DIR }}/node_modules
             ~/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('${{ env.WORKING_DIR }}/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-
 
       - name: Install dependencies
         working-directory: ${{ env.WORKING_DIR }}
@@ -46,21 +38,3 @@ jobs:
         env:
           CYPRESS_FAIL_FAST_STRATEGY: "run"
           CYPRESS_FAIL_FAST_PLUGIN: true
-
-      # - name: Run Cypress
-      #   uses: cypress-io/github-action@v5
-      #   with:
-      #     working-directory: ./E2E_tests
-
-      # - name: Update PR status
-      #   if: always()
-      #   run: |
-      #     if [ "${{ job.status }}" == "success" ]; then
-      #       echo "Tests passed!"
-      #     else
-      #       echo "Tests failed - PR cannot be merged"
-      #     fi
-
-      # - name: Run Cypress tests
-      #   working-directory: ${{ env.WORKING_DIR }}
-      #   run: yarn test --quiet --reporter minimal

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -25,13 +25,23 @@ jobs:
         with:
           node-version: 22.17.1
           cache: "yarn"
+          cache-dependency-path: ${{ env.WORKING_DIR }}/yarn.lock
+
+      # Кеширование node_modules и Cypress
+      - name: Cache dependencies and Cypress
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.WORKING_DIR }}/node_modules
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('${{ env.WORKING_DIR }}/yarn.lock') }}
 
       - name: Install dependencies
         working-directory: ${{ env.WORKING_DIR }}
         run: yarn install --frozen-lockfile
 
       - name: Run Cypress tests with fail-fast
-        working-directory: ./E2E_tests
+        working-directory: ${{ env.WORKING_DIR }}
         run: yarn cypress run --browser chrome
         env:
           CYPRESS_FAIL_FAST_STRATEGY: "run"

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Run Cypress
         uses: cypress-io/github-action@v5
         with:
+          auto-cancel-after-failures: 1
           working-directory: ./E2E_tests
 
       - name: Update PR status

--- a/E2E_tests/cypress.config.js
+++ b/E2E_tests/cypress.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      
+      require("cypress-fail-fast/plugin.js")(on, config);
       return config;
     },
   },

--- a/E2E_tests/cypress/e2e/Wikipedia/1-basic-loading.cy.js
+++ b/E2E_tests/cypress/e2e/Wikipedia/1-basic-loading.cy.js
@@ -3,6 +3,6 @@ describe("Wikipedia Smoke Test", () => {
     // Просто проверяем, что страница загружается
     cy.visit("https://ru.wikipedia.org", { timeout: 10000 })
       .title() // Проверяем title страницы
-      .should("include", "Википедия1");
+      .should("include", "Википедия");
   });
 });

--- a/E2E_tests/cypress/e2e/Wikipedia/1-basic-loading.cy.js
+++ b/E2E_tests/cypress/e2e/Wikipedia/1-basic-loading.cy.js
@@ -3,6 +3,6 @@ describe("Wikipedia Smoke Test", () => {
     // Просто проверяем, что страница загружается
     cy.visit("https://ru.wikipedia.org", { timeout: 10000 })
       .title() // Проверяем title страницы
-      .should("include", "Википедия");
+      .should("include", "Википедия1");
   });
 });

--- a/E2E_tests/cypress/e2e/Wikipedia/1-basic-loading.cy.js
+++ b/E2E_tests/cypress/e2e/Wikipedia/1-basic-loading.cy.js
@@ -1,8 +1,8 @@
-describe('Wikipedia Smoke Test', () => {
-  it('Главная страница открывается', () => {
+describe("Wikipedia Smoke Test", () => {
+  it("Главная страница открывается", () => {
     // Просто проверяем, что страница загружается
-    cy.visit('https://ru.wikipedia.org', { timeout: 10000 })
+    cy.visit("https://ru.wikipedia.org", { timeout: 10000 })
       .title() // Проверяем title страницы
-      .should('include', 'Википедия')
-  })
-})
+      .should("include", "Википедия1");
+  });
+});

--- a/E2E_tests/cypress/e2e/Wikipedia/3-navigation.cy.js
+++ b/E2E_tests/cypress/e2e/Wikipedia/3-navigation.cy.js
@@ -1,18 +1,15 @@
-describe('Wikipedia Navigation Test', () => {
-  it('Проверяет ссылки в главном меню', () => {
-    cy.visit('https://ru.wikipedia.org')
-    
+describe("Wikipedia Navigation Test", () => {
+  it("Проверяет ссылки в главном меню", () => {
+    cy.visit("https://ru.wikipedia.org");
+
     // 1. Проверяем меню навигации
-    cy.get('#p-navigation')
-      .should('be.visible')
+    cy.get("#p-navigation")
+      .should("be.visible")
       .within(() => {
         // 2. Проверяем основные пункты меню (без точных URL)
-        cy.contains('Заглавная страница')
-          .should('exist')
-        cy.contains('Содержание')
-          .should('exist')
-        cy.contains('Избранные статьи')
-          .should('exist')
-      })
-  })
-})
+        cy.contains("Заглавная страница").should("exist");
+        cy.contains("Содержание").should("exist");
+        cy.contains("Избранные статьи").should("exist");
+      });
+  });
+});

--- a/E2E_tests/cypress/e2e/Wikipedia/4-language.cy.js
+++ b/E2E_tests/cypress/e2e/Wikipedia/4-language.cy.js
@@ -1,15 +1,21 @@
-describe('Wikipedia Language Switching Test', () => {
-  it('Переключение на английскую версию статьи работает', () => {
-    cy.visit('https://ru.wikipedia.org/wiki/%D0%A1%D0%BE%D0%B1%D0%B0%D0%BA%D0%B0')
-      .get('.interwiki-en a')  
-      .invoke('attr', 'href')
+describe("Wikipedia Language Switching Test", () => {
+  it("Переключение на английскую версию статьи работает", () => {
+    cy.visit(
+      "https://ru.wikipedia.org/wiki/%D0%A1%D0%BE%D0%B1%D0%B0%D0%BA%D0%B0"
+    )
+      .get(".interwiki-en a")
+      .invoke("attr", "href")
       .then((enUrl) => {
-             expect(enUrl).to.include('https://en.wikipedia.org/wiki/Dog');        
-          cy.origin('https://en.wikipedia.org', { args: { enUrl } }, ({ enUrl }) => {
-          cy.visit(enUrl);
-          cy.url().should('include', 'https://en.wikipedia.org/wiki/Dog');
-          cy.get('h1').should('contain', 'Dog');  // Дополнительная проверка
-        });
+        expect(enUrl).to.include("https://en.wikipedia.org/wiki/Dog");
+        cy.origin(
+          "https://en.wikipedia.org",
+          { args: { enUrl } },
+          ({ enUrl }) => {
+            cy.visit(enUrl);
+            cy.url().should("include", "https://en.wikipedia.org/wiki/Dog");
+            cy.get("h1").should("contain", "Dog"); // Дополнительная проверка
+          }
+        );
       });
   });
 });

--- a/E2E_tests/cypress/support/e2e.js
+++ b/E2E_tests/cypress/support/e2e.js
@@ -14,4 +14,6 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+// import "./commands";
+
+require("cypress-fail-fast/index.js");

--- a/E2E_tests/package.json
+++ b/E2E_tests/package.json
@@ -5,9 +5,11 @@
   "license": "MIT",
   "scripts": {
     "start": "cypress open",
-    "test": "cypress run"
+    "test": "cypress run",
+    "test:ci": "cypress run --headless --quiet"
   },
   "devDependencies": {
-    "cypress": "^14.5.2"
+    "cypress": "^14.5.2",
+    "cypress-fail-fast": "^7.1.1"
   }
 }

--- a/E2E_tests/yarn.lock
+++ b/E2E_tests/yarn.lock
@@ -198,7 +198,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
-chalk@^4.1.0:
+chalk@4.1.2, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -297,6 +297,13 @@ cross-spawn@^7.0.0:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+cypress-fail-fast@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/cypress-fail-fast/-/cypress-fail-fast-7.1.1.tgz#4be6ddbed8c284358faf488c73b6bd87f69cda49"
+  integrity sha512-9qPXikVY20OWdc97DO2++0AS4IF9kB+vuPhP8/0wXchcnFIsiCiwvQhOEBSdVHr1mZi87h0Z8jYEB4VLPzNkGg==
+  dependencies:
+    chalk "4.1.2"
 
 cypress@^14.5.2:
   version "14.5.2"


### PR DESCRIPTION
* установил плагин cypress-fail-fast – завершает тесты при первом падении
* обновил /workflows/cypress-tests.yml:
  * кешируем зависимости
  * явно указываем стратегию падения для cypress-fail-fast